### PR TITLE
Change Android System Webview to Bromite Webview

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -101,6 +101,7 @@ downloadFromFdroid org.schabi.newpipe
 
 repo=https://fdroid.bromite.org/fdroid/repo/
 downloadFromFdroid org.bromite.bromite "Browser2 QuickSearchBox"
+downloadFromFdroid com.android.webview "WebView"
 
 echo >> apps.mk
 


### PR DESCRIPTION
The AOSP Webview is outdated (91.0.4472.114).
Bromite Webview has version 94.0.4606.102.

So why not using Bromite Webview while using Bromite Browser in FOSS?