### PR TITLE
removed droidguard.helper

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -93,7 +93,6 @@ repo=https://microg.org/fdroid/repo/
 downloadFromFdroid com.google.android.gms
 downloadFromFdroid com.google.android.gsf
 downloadFromFdroid com.android.vending
-downloadFromFdroid org.microg.gms.droidguard
 
 repo=https://archive.newpipe.net/fdroid/repo/
 #YouTube viewer


### PR DESCRIPTION
Not needed anymore, included in main gms package, see https://github.com/microg/GmsCore/releases/tag/v0.2.23.214816